### PR TITLE
Add card rank validation logic

### DIFF
--- a/src/utils/counting.js
+++ b/src/utils/counting.js
@@ -38,3 +38,12 @@ export function countCard(system, rank) {
 export function cumulativeCount(system, cards) {
   return cards.reduce((sum, card) => sum + countCard(system, card.rank), 0);
 }
+
+// -------- Card rank validation --------
+const VALID_RANKS = Object.keys(CARD_VALUES);
+export function validateCardRank(rank) {
+  if (!VALID_RANKS.includes(rank)) {
+    throw new RangeError(`Invalid card rank: ${rank}`);
+  }
+  return true;
+}

--- a/tests/cardValidation.test.js
+++ b/tests/cardValidation.test.js
@@ -1,0 +1,21 @@
+import { validateCardRank } from '../src/utils/counting.js';
+import { describe, it, expect } from 'vitest';
+
+describe('validateCardRank', () => {
+  const validRanks = ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K'];
+  const invalidRanks = ['0', '11', 'X', 'Ace', '', null, undefined, 5, '♠'];
+
+  it('accepts all valid ranks', () => {
+    validRanks.forEach(rank => {
+      expect(() => validateCardRank(rank)).not.toThrow();
+      expect(validateCardRank(rank)).toBe(true);
+    });
+  });
+
+  it('throws a RangeError for invalid ranks', () => {
+    invalidRanks.forEach(rank => {
+      expect(() => validateCardRank(rank)).toThrow(RangeError);
+      expect(() => validateCardRank(rank)).toThrow(`Invalid card rank: ${rank}`);
+    });
+  });
+});


### PR DESCRIPTION
Add a `validateCardRank` helper that throws a `RangeError` for any rank that is not one of the standard 13 ranks. A small test suite has been added to `tests/cardValidation.test.js`.

*This PR closes #9.*