### PR TITLE
feat: add bankroll simulation scripts and phase summaries

### DIFF
--- a/modules/state.js
+++ b/modules/state.js
@@ -115,6 +115,9 @@ let sessionState = {
   exitReason: null
 };
 
+// Export for ES module imports
+export const session = sessionState;
+
 Object.defineProperty(globalThis, 'session', {
   get: () => sessionState,
   set: v => { sessionState = v; },

--- a/script.js
+++ b/script.js
@@ -292,6 +292,17 @@ document.addEventListener('DOMContentLoaded', () => {
   // Expose for state module callbacks
   window.updateWongAdvisory = updateWongAdvisory;
 
+  // Dev test bridge: allow manual updateWongStreak calls from console
+  if (window.location.search.includes('debug=1')) {
+    window.updateWongStreak = updateWongStreak;
+    window.clearCurrentHandWongState = clearCurrentHandWongState;
+    console.log('[DEBUG] window.updateWongStreak and window.clearCurrentHandWongState exposed');
+    // Additional: expose state for inspection
+    window.__debugState = state;
+    console.log('[DEBUG] state exposed as window.__debugState');
+    console.log('[DEBUG] Example: __debugState.currentHandWongState = "exit"; updateWongStreak("exit"); repeat');
+  }
+
   // Insurance yes/no buttons
   document.getElementById('bjYes').onclick = () => {
     if (!state.insuranceResolved) {


### PR DESCRIPTION
- scripts/simulate_bankroll.py: Monte Carlo simulation for betting tier progression
- scripts/verify_tiers.js: validation script for tier advancement rules
- PHASE1_SUMMARY.md: first phase implementation report
- PHASE2_SUMMARY.md: second phase implementation report
- update index.html, styles.css, state.js, strategy.js: minor tweaks